### PR TITLE
fix: stop using target-typed new for Unity 2019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Removed
 
 ### Fixed
+- Compiler error in Unity 2019. (#1)
 
 ### Security
 

--- a/Packages/net.nekobako.gesture-weight-smoothing/Runtime/GestureWeightSmoothing.cs
+++ b/Packages/net.nekobako.gesture-weight-smoothing/Runtime/GestureWeightSmoothing.cs
@@ -20,7 +20,7 @@ namespace net.nekobako.GestureWeightSmoothing.Runtime
         public VRCAvatarDescriptor.AnimLayerType LayerType = VRCAvatarDescriptor.AnimLayerType.FX;
         public RuntimeAnimatorController AnimatorController = null;
         public bool WriteDefaults = false;
-        public List<ParameterMapping> ParameterMappings = new();
+        public List<ParameterMapping> ParameterMappings = new List<ParameterMapping>();
     }
 }
 


### PR DESCRIPTION
fix #1